### PR TITLE
AWS-47 - Setup Redis as MUC cache

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -9,7 +9,7 @@ project:  # Project specific configuration section
     DatabaseCmk: 'arn:aws:kms:us-west-2:095974944794:key/dcd37fd9-8fbf-4342-81a8-548681df5ffa'
     DatabaseEncrpytedBoolean: 'true'
     DatabaseInstanceType: 'db.r5.large'
-    DeploymentBranchCommitTag: 'master'
+    DeploymentBranchCommitTag: 'AWS-changes'
     DeploymentKey: 'arn:aws:secretsmanager:us-west-2:095974944794:secret:AWSCCLEDeploymentKey-WI4nl3'
     DomainName: ''
     EC2KeyName: CCLE-DR
@@ -18,17 +18,14 @@ project:  # Project specific configuration section
     Environment: 'stage'
     HostedZoneName: ''
     NumberOfAZs: 2
-    # PrivateSubnets: 'subnet-06a3baa880629ed73,subnet-0a64f75573465a5d7'
     PublicAlbAcmCertificate: ''
-    # PublicSubnets: 'subnet-0768522309f73972a,subnet-0e7454b0142913b70'
     UseRoute53Boolean: false
     UseApplicationCacheBoolean: 'true'
     UseCloudFrontBoolean: 'true'
     UseRoute53Boolean: 'false'
-    UseSessionCacheBoolean: 'false'
-    # VpcId: 'vpc-0017b23ff4df82e53'
+    UseSessionCacheBoolean: 'true'
     WebAsgMax: 4
-    WebInstanceType: c5.xlarge
+    WebInstanceType: t3.small
   regions: # List of AWS regions
     - us-west-2
   # Name of S3 bucket to upload project to

--- a/templates/00-master.yaml
+++ b/templates/00-master.yaml
@@ -645,6 +645,8 @@ Resources:
           !Ref MyRDSInstanceSecret
         MoodleConfigSecretArn:
           !Ref MoodleConfigSecret
+        CachePrefix:
+          !Ref CachePrefix
         DatabaseName:
           !Ref DatabaseName
         DeploymentKey:
@@ -677,8 +679,10 @@ Resources:
           !Join [',', !Ref PrivateSubnets]
         DomainName:
           !Ref DomainName
-        ElastiCacheClusterEndpointAddress:
+        SessionElastiCacheClusterEndpointAddress:
           ''
+        ApplicationElastiCacheClusterEndpointAddress:
+          !If [DeployApplicationCache, !GetAtt applicationcache.Outputs.ElastiCacheClusterEndpointAddress, '']
       TemplateURL: !Sub https://cat-ccle-aws-refarch-moodle${TemplateSource}.s3.us-west-2.amazonaws.com/aws-refarch-moodle/templates/04-web.yaml
   webcached:
     DependsOn: [ publicalb, rds, efsfilesystem, sessioncache ]
@@ -694,6 +698,8 @@ Resources:
           !Ref MyRDSInstanceSecret
         MoodleConfigSecretArn:
           !Ref MoodleConfigSecret
+        CachePrefix:
+          !Ref CachePrefix
         DatabaseName:
           !Ref DatabaseName
         DeploymentKey:
@@ -726,8 +732,10 @@ Resources:
           !Join [',', !Ref PrivateSubnets]
         DomainName:
           !Ref DomainName
-        ElastiCacheClusterEndpointAddress:
+        SessionElastiCacheClusterEndpointAddress:
           !GetAtt sessioncache.Outputs.ElastiCacheClusterEndpointAddress
+        ApplicationElastiCacheClusterEndpointAddress:
+          !If [DeployApplicationCache, !GetAtt applicationcache.Outputs.ElastiCacheClusterEndpointAddress, '']
       TemplateURL: !Sub https://cat-ccle-aws-refarch-moodle${TemplateSource}.s3.us-west-2.amazonaws.com/aws-refarch-moodle/templates/04-web.yaml
   cloudfront:
     Condition: DeployCloudFront

--- a/templates/03-elasticache.yaml
+++ b/templates/03-elasticache.yaml
@@ -115,19 +115,24 @@ Conditions:
 Resources:
 
   ElastiCacheCluster:
-    Type: AWS::ElastiCache::CacheCluster
+    Type: AWS::ElastiCache::ReplicationGroup
     Properties:
-      AZMode: cross-az
+      ReplicationGroupId: !Ref ElastiCacheClusterName
+      ReplicationGroupDescription: 'Redis cache'
+      AtRestEncryptionEnabled: true
+      TransitEncryptionEnabled: false # Must be false unless you implement AuthToken.
+      AutoMinorVersionUpgrade: true
+      AutomaticFailoverEnabled: true
+      MultiAZEnabled: true
       CacheNodeType: !Ref ElastiCacheNodeType
       CacheSubnetGroupName: !Ref ElastiCacheSubnetGroup
-      ClusterName: !Ref ElastiCacheClusterName
-      Engine: memcached
-      NumCacheNodes:
+      Engine: redis
+      NumCacheClusters:
         !Ref NumberOfSubnets
       Tags:
         - Key: Name
           Value: !Join [ '', [ 'Moodle / ', !Ref 'AWS::StackName' ] ]
-      VpcSecurityGroupIds:
+      SecurityGroupIds:
       - !Ref ElastiCacheSecurityGroup
   ElastiCacheSubnetGroup:
     Type: AWS::ElastiCache::SubnetGroup
@@ -158,4 +163,4 @@ Resources:
           ]
 Outputs:
   ElastiCacheClusterEndpointAddress:
-    Value: !GetAtt ElastiCacheCluster.ConfigurationEndpoint.Address
+    Value: !GetAtt ElastiCacheCluster.PrimaryEndPoint.Address

--- a/templates/04-web.yaml
+++ b/templates/04-web.yaml
@@ -32,7 +32,8 @@ Metadata:
         # - DatabaseMasterUsername
         # - DatabaseMasterPassword
         - DatabaseClusterEndpointAddress
-        - ElastiCacheClusterEndpointAddress
+        - SessionElastiCacheClusterEndpointAddress
+        - ApplicationElastiCacheClusterEndpointAddress
     - Label:
         default: File System Parameters
       Parameters:
@@ -46,8 +47,10 @@ Metadata:
       #   default: DB Master Password
       DatabaseName:
         default: DB Name
-      ElastiCacheClusterEndpointAddress:
-        default: ElastiCache Endpoint Address
+      SessionElastiCacheClusterEndpointAddress:
+        default: Session ElastiCache Endpoint Address
+      ApplicationElastiCacheClusterEndpointAddress:
+        default: Application ElastiCache Endpoint Address
       ElasticFileSystem:
         default: EFS File System
       EC2KeyName:
@@ -75,8 +78,11 @@ Metadata:
 
 Parameters:
 
-  ElastiCacheClusterEndpointAddress:
-    Description: The ElastiCacheCluster cluster endpoint address.
+  SessionElastiCacheClusterEndpointAddress:
+    Description: The Session ElastiCacheCluster cluster endpoint address.
+    Type: String
+  ApplicationElastiCacheClusterEndpointAddress:
+    Description: The Application ElastiCacheCluster cluster endpoint address.
     Type: String
   DatabaseClusterEndpointAddress:
     Description: The RDS cluster endpoint address.
@@ -99,6 +105,9 @@ Parameters:
   MyRDSInstanceSecretArn:
     Type: String
   MoodleConfigSecretArn:
+    Type: String
+  CachePrefix:
+    Description: '[ Optional ] Prefix before caching instances (e.g. <CachePrefix>session and <CachePrefix>application'
     Type: String
   DatabaseName:
     AllowedPattern: ^([a-zA-Z0-9]*)$
@@ -669,15 +678,48 @@ Resources:
                   $CFG->admin = 'admin';
 
                   // Configure Session Cache
-                  $SessionEndpoint = '${ElastiCacheClusterEndpointAddress}';
+                  $SessionEndpoint = '${SessionElastiCacheClusterEndpointAddress}';
                   if ($SessionEndpoint != '') {
                     $CFG->dbsessions = false;
-                    $CFG->session_handler_class = '\core\session\memcached';
-                    $CFG->session_memcached_save_path = $SessionEndpoint;
-                    $CFG->session_memcached_prefix = 'memc.sess.key.';
-                    $CFG->session_memcached_acquire_lock_timeout = 120;
-                    $CFG->session_memcached_lock_expire = 7100;
-                    $CFG->session_memcached_lock_retry_sleep = 150;
+                    $CFG->session_handler_class = '\core\session\redis';
+                    $CFG->session_redis_host = $SessionEndpoint;
+                    $CFG->session_redis_prefix = '${CachePrefix}.sess.key.';
+                    $CFG->session_redis_acquire_lock_timeout = 120;
+                    $CFG->session_redis_lock_expire = 7200;
+                    $CFG->session_redis_lock_retry = 100;
+                    $CFG->session_redis_serializer_use_igbinary = true;
+                  }
+
+                  // Configure Application Cache
+                  $ApplicationEndpoint = '${ApplicationElastiCacheClusterEndpointAddress}';
+                  if ($ApplicationEndpoint != '') {
+                    $CFG->tool_forcedcache_config_array = [
+                      'stores' => [
+                        '${CachePrefix}redis' => [
+                          'type' => 'redis',
+                          'config' => [
+                            'server' => $ApplicationEndpoint,
+                            'prefix' => '${CachePrefix}.app.key.',
+                            'serializer' => 2,  // Use igbinary serializer.
+                          ]
+                        ],
+                      ],
+                      'rules' => [
+                        'application' => [
+                          [
+                            'conditions' => [
+                              'canuselocalstore' => true
+                            ],
+                            'stores' => ['${CachePrefix}redis']
+                          ],
+                          [
+                            'stores' => ['${CachePrefix}redis']
+                          ]
+                        ],
+                        'session' => [],
+                        'request' => []
+                      ]
+                    ];
                   }
 
                   $CFG->forced_plugin_settings['tool_uclacoursecreator']['email_template_dir'] = '/var/www/moodle/ccle_email_templates/course_creator';
@@ -790,22 +832,7 @@ Resources:
               content:
                 !Sub |
                   #!/bin/bash -xe
-
-                  #Install memcached and then remove it. Memcached is not actually needed. We install amazon-elasticache-cluster-client.so instead. However Moodle does not detect memcached is installed. Therefore, this tricks Moodle into thinking it is installed.
-                  sudo yum install -y php-pecl-memcached
-                  sudo yum remove -y php-pecl-memcached
-
-                  wget -P /tmp/ https://elasticache-downloads.s3.amazonaws.com/ClusterClient/PHP-7.3/latest-64bit
-                  tar -xf '/tmp/latest-64bit'
-                  cp '/tmp/amazon-elasticache-cluster-client.so' /usr/lib64/php/modules/
-                  if [ ! -f /etc/php.d/50-memcached.ini ]; then
-                      touch /etc/php.d/50-memcached.ini
-                  fi
-                  echo 'extension=/usr/lib64/php/modules/amazon-elasticache-cluster-client.so;' >> /etc/php.d/50-memcached.ini
-
-                  # Commenting out since this will be done in the code instead.
-                  ##update Moodle source to use DYNAMIC_CLIENT_MODE so Moodle can detect changes to the elasticache cluster membership
-                  ##sed -i '/\$this->options\[Memcached::OPT_BUFFER_WRITES\] = \$bufferwrites;/a \ \ \ \ \ \ \ \ $this->options[Memcached::OPT_CLIENT_MODE] = Memcached::DYNAMIC_CLIENT_MODE;' /var/www/moodle/html/cache/stores/memcached/lib.php
+                  sudo yum install -y php-pecl-redis
 
               mode: 000500
               owner: root


### PR DESCRIPTION
* Changed ElasticCache to use Redis instead of Memcached
* Setting Moodle MUC application cache by using tool_forcedcache